### PR TITLE
SnapList reverted to default. A11y example updated to handle keyboard…

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,7 @@ This an internal util function used by `useDragToScroll` that can be useful for 
 - Version `4.2.0`. Add useScroll / goTo / animationEnabled option. Usefull to scroll on component mount.
 - Version `4.3.0`.
   - Removed `event.preventDefault()` form `mouseDown` so focus event can be propagated up in the DOM tree.
-  - `<SnapList>` and `<SnapItem>` now accept all the `HTMLDivElement` properties.
-  - `<SnapItem>` now accepts a `ref` property.
+  - `<SnapList>` now accept all the `HTMLDivElement` properties.
   - New className attached so it is easier to target it through CSS:
     - `<SnapList>` has a `.snaplist`.
     - `<SnapItem>` has a `.snapitem`.

--- a/src/SnapList.tsx
+++ b/src/SnapList.tsx
@@ -63,7 +63,7 @@ type WithChildren<T> = T & { children?: React.ReactNode };
 
 export const SnapList = React.forwardRef<HTMLDivElement, WithChildren<CarouselProps>>(SnapListComponent);
 
-interface SnapItemProps extends React.HTMLAttributes<HTMLDivElement> {
+export const SnapItem: React.FC<{
   margin?: {
     top?: string;
     right?: string;
@@ -75,12 +75,7 @@ interface SnapItemProps extends React.HTMLAttributes<HTMLDivElement> {
   snapAlign: 'start' | 'center' | 'end' | 'none';
   forceStop?: boolean;
   className?: string;
-}
-
-const SnapItemComponent: React.FC<SnapItemProps> = (
-  { children, margin, snapAlign = 'center', forceStop = false, width, height, className, ...props },
-  ref: React.Ref<HTMLDivElement>,
-) => (
+}> = ({ children, margin, snapAlign = 'center', forceStop = false, width, height, className }) => (
   <div
     className={mergeStyles(
       'snapitem',
@@ -97,11 +92,7 @@ const SnapItemComponent: React.FC<SnapItemProps> = (
       width,
       height,
     }}
-    ref={ref}
-    {...props}
   >
     {children}
   </div>
 );
-
-export const SnapItem = React.forwardRef<HTMLDivElement, WithChildren<SnapItemProps>>(SnapItemComponent);


### PR DESCRIPTION
… Enter and space events. Also updated ref management on children